### PR TITLE
Add map support (getEnvMap)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ testall: test dev
 	echo '{{ getEnv "TEST2" }}' > test/output/c.conf.tpl_new
 	echo '{{ getEnv "TEST1" }}' > test/output/d.conf.tpl_single
 	echo '{{ range getEnvArray "ARRAY"}}{{.}}{{ end }}' > test/output/e.conf.tpl_array
+	echo '{ {{ range getEnvArray "KEYS" }}\n\t{\n\t\t"key": "{{ . }}",\n\t\t"value": "{{ getEnvMap "MAP" . }}",\n\t},{{ end }}\n}' > test/output/m.conf.tpl_map
 	bats test/bats/tests.bats
 
 build: test

--- a/README.md
+++ b/README.md
@@ -47,3 +47,33 @@ ruby
 
 
 ```
+
+### Sample with map:
+Variable with map should looks like this:
+```
+KEYS="key1,key2" MAP="{ \"key1\": \"key1-value\", \"key2\": \"key2-value\"}"
+```
+
+Template file which use this map:
+```
+{ {{ range getEnvArray "KEYS" }}
+  {
+    "key": "{{ . }}",
+    "value": "{{ getEnvMap "MAP" . }}",
+  },{{ end }}
+}
+```
+
+Output file:
+```
+{
+  {
+    "key": "key1",
+    "value": "key1-value",
+  },
+  {
+    "key": "key2",
+    "value": "key2-value",
+  },
+}
+```

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -55,6 +56,19 @@ func getEnvArray(envName string) ([]string, error) {
 	return strings.Split(env, ","), nil
 }
 
+func getEnvMap(envName string, envKey string) (string, error) {
+	jsonString, err := getEnv(envName)
+
+	if err != nil {
+		return "", err
+	}
+
+	var jsonResult map[string]interface{}
+	json.Unmarshal([]byte(jsonString), &jsonResult)
+
+	return jsonResult[envKey].(string), nil
+}
+
 func renderTemplate(templateText string) (templateResultBuffer bytes.Buffer, err error) {
 
 	// Create a FuncMap with which to register the function.
@@ -64,6 +78,9 @@ func renderTemplate(templateText string) (templateResultBuffer bytes.Buffer, err
 		},
 		"getEnvArray": func(key string) ([]string, error) {
 			return getEnvArray(key)
+		},
+		"getEnvMap": func(envName string, envKey string) (string, error) {
+			return getEnvMap(envName, envKey)
 		},
 	}
 

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -34,12 +34,17 @@ func TestSearchAndFill(t *testing.T) {
 		}, {
 			fileName:    "../test/templates/confB/c.conf",
 			fileContent: "a1\na2\na3\n",
+		}, {
+			fileName:    "../test/templates/confC/a.conf",
+			fileContent: "{ \n\t{\n\t\t\"key\": \"key1\",\n\t\t\"value\": \"key1-value\",\n\t},\n\t{\n\t\t\"key\": \"key2\",\n\t\t\"value\": \"key2-value\",\n\t},\n}\n",
 		},
 	}
 
 	os.Setenv("TEST1", "test_1")
 	os.Setenv("TEST2", "test_2")
 	os.Setenv("ARRAY", "a1,a2,a3")
+	os.Setenv("KEYS", "key1,key2")
+	os.Setenv("MAP", "{\"key1\":\"key1-value\",\"key2\":\"key2-value\"}")
 
 	if err := templates.SearchAndFill(dirToScanTest, fileExtTest, false); err != nil {
 		t.Error("Could not search and fill templates. Error: ", err.Error())

--- a/test/bats/tests.bats
+++ b/test/bats/tests.bats
@@ -73,4 +73,12 @@ filler=$PWD/filler
     [ $status -eq 0 ]
 }
 
+@test "filler-run-with-map" {
+    export KEYS="key1,key2"
+    export MAP="{\"key1\":\"key1-value\",\"key2\":\"key2-value\"}"
+    run $filler --src test/output --ext tpl_map
+    [ $status -eq 0 ]
+    result=$(grep -c key.-value test/output/m.conf)
+    [ $result -eq 2 ]
+}
 

--- a/test/templates/confC/a.conf.tpl
+++ b/test/templates/confC/a.conf.tpl
@@ -1,0 +1,6 @@
+{ {{ range getEnvArray "KEYS" }}
+	{
+		"key": "{{ . }}",
+		"value": "{{ getEnvMap "MAP" . }}",
+	},{{ end }}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = "0.2.0"
+const version = "0.3.0"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Signed-off-by: Marcin Janas <marcin.janas@airhelp.com>

Description: I need this functionality to generate a logstash configuration for cloudwatch (zulu influxdb)

```
=== RUN   TestSearchAndFill
--- PASS: TestSearchAndFill (0.00s)
PASS
coverage: 78.8% of statements
ok      github.com/AirHelp/filler/templates     0.007s  coverage: 78.8% of statements
=== RUN   TestGet
--- PASS: TestGet (0.00s)
PASS
coverage: 100.0% of statements
ok      github.com/AirHelp/filler/version       0.002s  coverage: 100.0% of statements
go build
echo '{{ getEnv "TEST1" }}' > test/output/a.conf.tpl
echo '{{ getEnv "TEST2" }}' > test/output/b.conf.tpl
echo '{{ getEnv "TEST2" }}' > test/output/c.conf.tpl_new
echo '{{ getEnv "TEST1" }}' > test/output/d.conf.tpl_single
echo '{{ range getEnvArray "ARRAY"}}{{.}}{{ end }}' > test/output/e.conf.tpl_array
echo '{ {{ range getEnvArray "KEYS" }}\n\t{\n\t\t"key": "{{ . }}",\n\t\t"value": "{{ getEnvMap "MAP" . }}",\n\t},{{ end }}\n}' > test/output/m.conf.tpl_map
bats test/bats/tests.bats
 ✓ Check that the filler binary is available
 ✓ help
 ✓ version
 ✓ filler-run-without-ext
 ✓ filler-run-with-ext
 ✓ filler-run-with-single-file
 ✓ filler-run-with-missing-var
 ✓ filler-run-with-delete
 ✓ filler-run-with-array
 ✓ filler-run-with-map

10 tests, 0 failures
```