### PR TITLE
Use latest Go version for Filler testing pipeline

### DIFF
--- a/JenkinsPods.yaml
+++ b/JenkinsPods.yaml
@@ -5,17 +5,20 @@ metadata:
     app: golang
 spec:
   containers:
-  - name: golang
-    image: golang:1.11.2-alpine
-    command:
-    - cat
-    tty: true
-    resources:
-      requests:
-        cpu: 100m
-        memory: 256Mi
-    env:
-      - name: GO111MODULE
-        value: "on"
-      - name: CGO_ENABLED
-        value: 0
+    - name: golang
+      image: golang:alpine
+      command:
+        - cat
+      tty: true
+      resources:
+        limits:
+          cpu: 1
+          memory: 1G
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      env:
+        - name: GO111MODULE
+          value: "on"
+        - name: CGO_ENABLED
+          value: "0"


### PR DESCRIPTION
Let's use the latest and don't waste our time for bumping it over and over.