### PR TITLE
feat/stalebot/limit-to-only-pulls

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,3 +17,5 @@ markComment: >
 closeComment: false
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true
+# Limit to only `issues` or `pulls`
+only: pulls


### PR DESCRIPTION
Requestor/Issue: @marcin-janas
Risk (low/med/high): low
Tested (yes/no): no
Description/Why: the excludeProjects option doesn't work for us as we are using GitHub projects in beta version
https://github.com/AirHelp/ah-devops/issues/7967
