### PR TITLE
Pin GitHub Action versions to sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
           go-version: '1.19.x'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Requestor/Issue: https://github.com/AirHelp/ah-devops/issues/15247
Risk (low/med/high): low
Tested (yes/no): yes
Description/Why: As recommended by GitHub https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions, pin all GitHub Actions to specific commit hashes instead of version tags to mitigate against future supply chain attacks. The script that made the change is here: https://github.com/AirHelp/ah-devops/pull/15249