### PR TITLE
INFRA-937: chore(filler): bump Go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/AirHelp/filler
 
-go 1.24
-
-toolchain go1.24.1
+go 1.26
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## What

Bump Go version to 1.26 in `go.mod` (removes `toolchain` directive).

## Why

Stay on the latest stable Go release.

## Risk

Low — version bump only, no logic changes.

## Jira

INFRA-937